### PR TITLE
Add query parameter section

### DIFF
--- a/draft-romijn-grow-rpsl-registry-scoped-members-01.md
+++ b/draft-romijn-grow-rpsl-registry-scoped-members-01.md
@@ -233,6 +233,22 @@ The RS-SECOND object in the OTHER registry is never looked up,
 and AS65002 is not included. This would happen even if there was no
 RS-SECOND object found in RIPE.
 
+### Query parameters
+
+When querying a set to resolve its members, IRR software typically
+expects the primary key of the set as a query parameter from the user.
+This reference is also ambiguous without referring a specific registry.
+
+IRR software MUST support a user-provided parameter to restrict the initial lookup
+of the set object to a specific registry.
+This restriction MUST NOT apply to further lookups performed by the IRR software
+when resolving the set, i.e., this restriction also does not cascade.
+
+For text based queries, IRR softwazre is RECOMMENDED to allow this parameter to be
+provided in similar syntax as the `src-members` value, e.g. RIPE::AS-DEMO,
+to query the object with primary key AS-DEMO in registry RIPE,
+and then continue resolving its members.
+
 # Relation to `(mp-)members`
 
 Existing IRR software will not be aware of the new `src-members` attribute


### PR DESCRIPTION
This only works if I am reading correctly, that "RIPE::AS-DEMO" is never a valid RPSL PK itself. Otherwise, it adds ambiguity. Alternative: require two separate parameters.

Note that existing mechanisms like `-s`/`!s` don't work here, as they restrict all subsequent lookups of any kind.